### PR TITLE
remove accidental '#' character in DaytimeServer.java

### DIFF
--- a/src/network/DaytimeServer.java
+++ b/src/network/DaytimeServer.java
@@ -16,7 +16,7 @@ public class DaytimeServer {
         } catch (IOException e) {
             System.err.println("FEHLER: Port 10013 bereits geöffnet");
             System.exit(1);
-        }#
+        }
 
         // accept wartet 1. auf einen Client, der sich verbinden will
         // und 2. stellt die Verbindung her


### PR DESCRIPTION
# Description
This pull request addresses an issue where an accidental '#' character was inserted into `DaytimeServer.java`. The purpose of this change is to remove the '#' character and restore the correct functionality of the code.

# Changes Made
The change involves removing the '#' character from the following line:

```diff
    System.exit(1);
-}#
+}
```